### PR TITLE
Fix NodeJS Worflow fail

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -25,5 +25,6 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+    - run: npm install
     - run: npm ci
     - run: npm run build --if-present


### PR DESCRIPTION
Fix the NodeJS Github Actions fail.
It did fail because npm ci command needs a package-lock.jsonn file to run.